### PR TITLE
add the status badge of publish image workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # docker-gcloud-sdk
 
 [![Check Version](https://github.com/shirakiya/docker-gcloud-sdk/actions/workflows/check_version.yml/badge.svg?branch=main)](https://github.com/shirakiya/docker-gcloud-sdk/actions/workflows/check_version.yml)
+[![Publish image](https://github.com/shirakiya/docker-gcloud-sdk/actions/workflows/publish.yml/badge.svg)](https://github.com/shirakiya/docker-gcloud-sdk/actions/workflows/publish.yml)
 
 This project builds and publishes the docker images that contains [gcloud-sdk](https://cloud.google.com/cli)
 and [kubectl](https://kubernetes.io/ja/docs/reference/kubectl/overview/). The Docker Hub repository page is below.


### PR DESCRIPTION
It's easy to check the health of ["Publish image"](https://github.com/shirakiya/docker-gcloud-sdk/actions/workflows/publish.yml) workflow.