### PR TITLE
replace from `google-cloud-sdk` to `google-cloud-cli`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,11 @@ FROM python:3.12.2
 COPY gcloud_sdk_version.txt /tmp/gcloud_sdk_version.txt
 
 RUN GCLOUD_SDK_VERSION=`cat /tmp/gcloud_sdk_version.txt | tr -d '\n'` && \
-    echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | \
+    echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | \
     tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
-    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - && \
+    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && \
     apt-get update -y && \
-    apt-get install google-cloud-sdk=${GCLOUD_SDK_VERSION}-0 kubectl -y && \
+    apt-get install -y google-cloud-cli=${GCLOUD_SDK_VERSION}-0 kubectl && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Replace installed package to `google-cloud-cli` because `google-cloud-sdk` is deprecated and cannot be install after 467.0.0.

ref.
- https://cloud.google.com/sdk/docs/install?hl=ja#deb
- https://www.googlecloudcommunity.com/gc/Developer-Tools/apt-get-install-google-cloud-sdk-stopped-working/m-p/707579