### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/check_version.yml
+++ b/.github/workflows/check_version.yml
@@ -17,7 +17,7 @@ jobs:
         run: echo "${{ steps.current_gcloud_sdk_version.outputs.version }}"
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v3.0.1
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
         with:
           version: latest
       - id: latest_gcloud_sdk_version

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,21 +11,21 @@ jobs:
   build_and_push:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Log in to Docker Hub
-        uses: docker/login-action@v4.4.0
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Setup QEMU
-        uses: docker/setup-qemu-action@v4.2.0
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
       - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v4.2.0
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       - id: get_version
         name: Get version
         run: echo "version=$(cat ./gcloud_sdk_version.txt)" >> $GITHUB_OUTPUT
       - name: Build and push
-        uses: docker/build-push-action@v7.3.0
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
## Why

Pin GitHub Actions to immutable commit SHAs to prevent tags from changing the workflow behavior unexpectedly.

## What

Replace every workflow action tag with its corresponding commit SHA and retain the original tag as an inline comment.