### PR TITLE
Pin actions checkout dependency

### DIFF
--- a/.github/workflows/check_version.yml
+++ b/.github/workflows/check_version.yml
@@ -8,7 +8,7 @@ jobs:
   check_version:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - id: current_gcloud_sdk_version
         name: Get current gcloud-sdk version


### PR DESCRIPTION
## Why
Pin the GitHub Actions checkout action to its immutable commit SHA to keep the workflow dependency secure and reproducible.

## What
Update the version-check workflow to use the pinned SHA for actions/checkout v7.0.1.